### PR TITLE
Set loglevel for cli with environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use `LOGLEVEL` environment variable to set log level in the cli
+
 ## [0.1.0] - 2019-12-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Because a profile can specify a `keyid`, you can have named profiles not only fo
 
 Most issues are related to authentication or permissions with your cloud provider.
 
+With the `discreetly` cli, you can also change the logging level by setting the `LOGLEVEL` environment variable, e.g.
+
+```console
+$ LOGLEVEL=DEBUG discreetly get my/super/secret
+```
+
 ### AWS
 
 Verify that you can use the AWS CLI to access Parameter Store, e.g.:

--- a/src/discreetly/cli.py
+++ b/src/discreetly/cli.py
@@ -1,10 +1,15 @@
+"""Command line interface for discreetly.
+
+"""
+
 import click
 import json
 import logging
+import os
 import discreetly
 
-logging.basicConfig(level=logging.DEBUG)
-logging.getLogger("discreetly").addHandler(logging.StreamHandler())
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "WARN"))
+logging.getLogger(__name__)
 
 
 @click.group()


### PR DESCRIPTION
Changes default loglevel from DEBUG to WARN

Uses value from environment variable `LOGLEVEL` if set, falling back to WARN

Closes #1