### PR TITLE
[#c0eutiqt]/1028 fix discreetly

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@
 #   Requires use_python() to be defined in ~/.config/direnv/direnvrc
 #   see: https://github.com/direnv/direnv/wiki/Python#pyenv
 if has pyenv; then
-  layout pyenv 2.7.16 3.7.3
+  layout pyenv 3.7.3
 else
   layout python
 fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 2
       matrix:
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [3.6, 3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ acme.get('acme/prod/postgres/password') # no need to specify the keyid for get
 
 ## Development
 
-`discreetly` is written in Python and supports Python 2.7 and 3.6+.
+`discreetly` is written in Python and supports Python 2.7 and 3.6+
 
 After cloning the repo, run `pip install -r requirements.txt` to install the required development dependencies (e.g. pytest, flake8, etc.)
 
 You can run `pytest` to run the unit tests locally or `tox` to run all the tests under Python 2.7 and 3.x.
+
+**Note** from version `0.2.0` onwards, `discreetly` only supports Python 3.6+
 
 ### Releases
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 extras_require = {
     "aws": ["boto3"],
-    "gcp": ["google-cloud-kms<2.0.0", "google-cloud-datastore"],
+    "gcp": ["google-cloud-kms>=2.0.0,<3.0.0", "google-cloud-datastore"],
 }
 
 extras_require["cli"] = sum(extras_require.values(), ["click"])
@@ -33,7 +33,7 @@ extras_require["test"] = [
     "mock",
     "flake8",
     "moto",
-    'black; python_version >= "3.6.0"',
+    "black",
 ]
 
 

--- a/src/discreetly/backends/gcp/__init__.py
+++ b/src/discreetly/backends/gcp/__init__.py
@@ -93,14 +93,16 @@ class GCPBackend(with_metaclass(ABCMeta, AbstractBackend)):
         if cryptokey is None:
             cryptokey = self.default_keyid
             logger.warn("No cryptokey specified. Trying default")
-        response = self.kms_client.decrypt(cryptokey, ciphertext)
+        response = self.kms_client.decrypt(
+            request={"name": cryptokey, "ciphertext": ciphertext}
+        )
         return response.plaintext.decode()
 
     def _encrypt_value(self, plaintext, cryptokey=None):
         if cryptokey is None:
             cryptokey = self.default_keyid
         response = self.kms_client.encrypt(
-            cryptokey, plaintext.encode("utf-8")
+            request={"name": cryptokey, "plaintext": plaintext.encode("utf-8")}
         )
         return response.ciphertext
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-# envlist = py{27,35,36,37,38}
-envlist = py{27,37}
+envlist = py{36,37,38}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
* **Trello Ticket**: https://trello.com/c/cOeutIqt/1028-fix-discreetly
* Other Relevant Links [google-cloud-kms 2.0.0 migration guide](https://googleapis.dev/python/cloudkms/latest/UPGRADING.html)

# What does this Pull Request do?
- update discreetly to use google-cloud-kms version >=2.0.0 and <3.0.0
- update tests for test-gcp accordingly
- update docs for new changes
- update .envrc for python 3.7.3
- add template for making commit and PRs

prepare to release `discreetly` v0.2.0

# How should this be validated?
1. uninstall `google-cloud-kms`
```console
pip uninstall google-cloud-kms
```

2. install dependencies:
```console
pip install -r requirements.txt
```

3. run pytest should be sufficient
```console
pytest
```

4. Follow the `README.md` and verify those functions work correctly.

# Checklist
<!-- This is a reminder checklist that you've taken all necessary steps to prepare this PR
Replace `[ ]` with `[x]` for all that apply.-->
- [x] You've fetched and rebased your branch on an **up-to-date** version `master`
- [x] PR contains new tests relevant for the feature/problem this PR is addressing
- [x] All tests and linting pass
- [x] Your commits have been squashed/rebased/etc. for reviewer clarity


# Additional Notes:
This PR is for release of v0.2.0 which supports `python` 3 only
Other PR (https://github.com/tra-sg/discreetly/pull/11) is for release of v0.1.2 which also supports `python` 2

# Interested parties
@ghosalya as main reviewer
@eddies 
